### PR TITLE
Add TSTC to edu domain list

### DIFF
--- a/lib/domains/edu/tstc/mymail.txt
+++ b/lib/domains/edu/tstc/mymail.txt
@@ -1,0 +1,2 @@
+Texas State Technical College
+Texas State Technical College


### PR DESCRIPTION
A new file has been created under the education domains directory for Texas State Technical College. This addition will allow us to recognize emails from this institution.
